### PR TITLE
Insert into Request Vector only if Request is not already there

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ path = "src/server.rs"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.64"
 itertools = "0.10.*"
-aether_lib = { git = "https://github.com/Prototype-Aether/Aether-Lib.git", branch = "tracker-packet" }
+aether_lib = { git = "https://github.com/Prototype-Aether/Aether-Lib.git", branch = "staged" }

--- a/src/server.rs
+++ b/src/server.rs
@@ -81,15 +81,22 @@ impl TrackerServer {
                             port: src.port(),
                             ip: ip_bytes,
                         };
-                        
-                        self.requests.entry(data.peer_username).or_insert(Vec::new()).push(connection);
+
+                        let requests_list = self
+                            .requests
+                            .entry(data.peer_username)
+                            .or_insert(Vec::new());
+
+                        if !requests_list.contains(&connection) {
+                            requests_list.push(connection);
+                        }
                     }
 
                     Some(3) => {
                         let connection_list = self.requests.get(&data.username);
                         let connection_list: Vec<ConnectionRequest> = match connection_list {
-                            None => {Vec::new()},
-                            Some(conn_list) => {conn_list.clone()}
+                            None => Vec::new(),
+                            Some(conn_list) => conn_list.clone(),
                         };
 
                         let packet: TrackerPacket = TrackerPacket {


### PR DESCRIPTION
The request list kept growing even if the same request already existed. So, added a check to see if it already exists. Now, a new request is added only if it doesn't exist already.

Right now the comparison is exact. But we should change it later to only compare username and identity number and if the port and ip are different, we should update it.

Also updated `aether_lib` dependency to use `staged` branch.