### PR TITLE
Github Action worflow to release binary on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,8 @@
-name: Build
+name: Publish Release
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main, staged ]
+    branches: [ automated-release-test ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Create Tag
         id: create_tag
         run: |
-          tag=v$(cat Cargo.toml | cat Cargo.toml | grep "^version" | head -1 | sed "s/version = //" | sed "s/\"//g")
+          tag=v$(cat Cargo.toml | cat Cargo.toml | grep "^version" | head -1 | sed "s/version = //" | sed "s/\"//g")-alpha
           echo "::set-output name=tag::$tag"
       - name: Delete Existing
         uses: cb80/delrel@latest
@@ -35,7 +35,7 @@ jobs:
           tag_name: ${{steps.create_tag.outputs.tag}}
           release_name: ${{steps.create_tage.outputs.tag}}
           draft: true
-          prerelease: true
+          prerelease: false
       - name: Upload Release
         uses: actions/upload-release-asset@v1.0.1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Publish Release
 
 on:
   push:
-    branches: [ automated-release-test ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,18 @@ jobs:
           release_name: ${{steps.create_tage.outputs.tag}}
           draft: true
           prerelease: false
-
+      - name: Upload Release
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: target/release/server
+          asset_name: aether-tracker-server
+          asset_content_type: application/x-pie-executable
+      - name: Publish Release
+        uses: eregon/publish-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_id: ${{ steps.create_release.outputs.id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main, staged ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    name: Create Github Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Build Release Binary
+        run: cargo build --release
+      - name: Create Tag
+        id: create_tag
+        run: |
+          tag=v$(cat Cargo.toml | cat Cargo.toml | grep "^version" | head -1 | sed "s/version = //" | sed "s/\"//g")
+          echo "::set-output name=tag::$tag"
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          tag_name: ${{steps.create_tag.outputs.tag}}
+          release_name: ${{steps.create_tage.outputs.tag}}
+          draft: true
+          prerelease: false
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build Release Binary
-        run: cargo build --release
+        id: build
+        run: |
+          cargo build --release --target x86_64-unknown-linux-gnu
+          # get the mimetype of the application
+          mimetype=$(file --mime-type target/x86_64-unknown-linux-gnu/release/server | cut -d':' -f2 | xargs)
+          echo "::set-output name=mimetype::$mimetype"
       - name: Create Tag
         id: create_tag
         run: |
@@ -42,9 +47,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: target/release/server
-          asset_name: aether-tracker-server
-          asset_content_type: application/x-pie-executable
+          asset_path: target/x86_64-unknown-linux-gnu/release/server
+          asset_name: aether-tracker-server-x86_64-unknown-linux-gnu
+          asset_content_type: ${{ steps.build.mimetype }}
       - name: Publish Release
         uses: eregon/publish-release@v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
         run: |
           tag=v$(cat Cargo.toml | cat Cargo.toml | grep "^version" | head -1 | sed "s/version = //" | sed "s/\"//g")
           echo "::set-output name=tag::$tag"
+      - name: Delete Existing
+        uses: cb80/delrel@latest
+        with:
+          tag: ${{steps.create_tag.outputs.tag}}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -31,7 +35,7 @@ jobs:
           tag_name: ${{steps.create_tag.outputs.tag}}
           release_name: ${{steps.create_tage.outputs.tag}}
           draft: true
-          prerelease: false
+          prerelease: true
       - name: Upload Release
         uses: actions/upload-release-asset@v1.0.1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: target/x86_64-unknown-linux-gnu/release/server
           asset_name: aether-tracker-server-x86_64-unknown-linux-gnu
-          asset_content_type: ${{ steps.build.mimetype }}
+          asset_content_type: ${{ steps.build.outputs.mimetype }}
       - name: Publish Release
         uses: eregon/publish-release@v1
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracker"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 
 [lib]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,10 +1,10 @@
 use aether_lib::tracker::{ConnectionRequest, TrackerPacket};
+use dotenv::dotenv;
 use netfunc::{identity_confirm, PeerInfo};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::env;
 use std::net::{IpAddr, UdpSocket};
-use dotenv::dotenv;
 
 struct TrackerServer {
     socket: UdpSocket,
@@ -144,7 +144,15 @@ impl TrackerServer {
 
 fn main() {
     dotenv().ok();
-    let port = env::var("TRACKER_PORT").expect("TRACKER_PORT not defined as ENV variable.");
+    let port = match env::var("TRACKER_PORT") {
+        Ok(port) => port,
+        Err(_) => {
+            println!("Port not defined.\nSet TRACKER_PORT environment variable to the port that the server needs to listen to");
+            println!("For example, TRACKER_PORT=8982");
+            return;
+        }
+    };
+
     let tracker_addr = format!("0.0.0.0:{}", port);
     println!("Listening on {}", port);
 


### PR DESCRIPTION
Setup a GitHub action to release a binary (for `x86_65-unknown-linux` target), when a commit is made to main branch.

The version and tag is defined by the `version` field in `Cargo.toml` if the version is not updated on a commit, the previous release of the same version is replaced with the new binary.